### PR TITLE
Added tests for H I bf & ff opacities and improved documentation

### DIFF
--- a/src/continuum_opacity/hydrogenic_bf_ff.jl
+++ b/src/continuum_opacity/hydrogenic_bf_ff.jl
@@ -148,8 +148,6 @@ integral.
 
 # Arguments
 - `Z::Integer`: Z is the atomic number of the species (e.g. 1 for H I or 2 for He II)
-- `nmax_explicit_sum::Integer`: The highest energy level whose opacity contribution is included in
-   the explicit sum. The contributions from higher levels are included in the integral.
 - `nsdens_div_partition::Flt` is the total number density of the species divided by the species's
    partition function.
 - `ν::Flt`: frequency in Hz
@@ -157,14 +155,16 @@ integral.
 - `T::Flt`: temperature in K
 - `ion_energy::AbstractFloat`: the ionization energy from the ground state (in eV). This can be 
    estimated as Z²*Rydberg_H (Rydberg_H is the ionization energy of Hydrogen)
+- `nmax_explicit_sum::Integer`: The highest energy level whose opacity contribution is included in
+   the explicit sum. The contributions from higher levels are included in the integral.
 - `integrate_high_n::bool`: When this is `false`, bf opacity from higher energy states are not
    estimated at all. Default is `true`.
 
 # Notes
 This follows the approach described in section 5.1 of Kurucz (1970).
 """
-function hydrogenic_bf_opacity(Z::Integer, nmax_explicit_sum::Integer, nsdens_div_partition::Flt,
-                               ν::Flt, ρ::Flt, T::Flt, ion_energy::Flt,
+function hydrogenic_bf_opacity(Z::Integer, nsdens_div_partition::Flt, ν::Flt, ρ::Flt, T::Flt,
+                               ion_energy::Flt, nmax_explicit_sum::Integer,
                                integrate_high_n::Bool = true) where {Flt<:AbstractFloat}
     ionization_freq = _eVtoHz(ion_energy)
 

--- a/src/continuum_opacity/hydrogenic_bf_ff.jl
+++ b/src/continuum_opacity/hydrogenic_bf_ff.jl
@@ -192,20 +192,20 @@ end
 # this table is taken from section 5.1 of Kurucz (1970)
 const _ff_interpolator = begin
     table_val = [5.53 5.49 5.46 5.43 5.40 5.25 5.00 4.69 4.48 4.16 3.85;
-                   4.91 4.87 4.84 4.80 4.77 4.63 4.40 4.13 3.87 3.52 3.27;
-                   4.29 4.25 4.22 4.18 4.15 4.02 3.80 3.57 3.27 2.98 2.70;
-                   3.64 3.61 3.59 3.56 3.54 3.41 3.22 2.97 2.70 2.45 2.20;
-                   3.00 2.98 2.97 2.95 2.94 2.81 2.65 2.44 2.21 2.01 1.81;
-                   2.41 2.41 2.41 2.41 2.41 2.32 2.19 2.02 1.84 1.67 1.50;
-                   1.87 1.89 1.91 1.93 1.95 1.90 1.80 1.68 1.52 1.41 1.30;
-                   1.33 1.39 1.44 1.49 1.55 1.56 1.51 1.42 1.33 1.25 1.17;
-                   0.90 0.95 1.00 1.08 1.17 1.30 1.32 1.30 1.20 1.15 1.11;
-                   0.45 0.48 0.52 0.60 0.75 0.91 1.15 1.18 1.15 1.11 1.08;
-                   0.33 0.36 0.39 0.46 0.59 0.76 0.97 1.09 1.13 1.10 1.08;
-                   0.19 0.21 0.24 0.28 0.38 0.53 0.76 0.96 1.08 1.09 1.09]
-    # The x-axis is log₁₀(RydbergH*Z²/(k*T))
+                 4.91 4.87 4.84 4.80 4.77 4.63 4.40 4.13 3.87 3.52 3.27;
+                 4.29 4.25 4.22 4.18 4.15 4.02 3.80 3.57 3.27 2.98 2.70;
+                 3.64 3.61 3.59 3.56 3.54 3.41 3.22 2.97 2.70 2.45 2.20;
+                 3.00 2.98 2.97 2.95 2.94 2.81 2.65 2.44 2.21 2.01 1.81;
+                 2.41 2.41 2.41 2.41 2.41 2.32 2.19 2.02 1.84 1.67 1.50;
+                 1.87 1.89 1.91 1.93 1.95 1.90 1.80 1.68 1.52 1.41 1.30;
+                 1.33 1.39 1.44 1.49 1.55 1.56 1.51 1.42 1.33 1.25 1.17;
+                 0.90 0.95 1.00 1.08 1.17 1.30 1.32 1.30 1.20 1.15 1.11;
+                 0.45 0.48 0.52 0.60 0.75 0.91 1.15 1.18 1.15 1.11 1.08;
+                 0.33 0.36 0.39 0.46 0.59 0.76 0.97 1.09 1.13 1.10 1.08;
+                 0.19 0.21 0.24 0.28 0.38 0.53 0.76 0.96 1.08 1.09 1.09]
+    # The x-axis is log₁₀(RydbergH*Z²/(k*T)) = log₁₀(γ²)
     xaxis = [-3.0, -2.5, -2.0, -1.5, -1.0, -0.5,  0.0,  0.5,  1.0,  1.5,  2.0]
-    # The y-axis is log₁₀(h*ν/(k*T))
+    # The y-axis is log₁₀(h*ν/(k*T)) = log₁₀(u)
     yaxis = [-4.0, -3.5, -3.0, -2.5, -2.0, -1.5, -1.0, -0.5,  0.0,  0.5,  1.0,  1.5]
 
     # Since the grid is regularly spaced, we could probably make this faster
@@ -214,13 +214,42 @@ const _ff_interpolator = begin
 end
 
 """
+    gaunt_ff_kurucz(log_u, log_γ2)
+
+computes the thermally averaged free-free gaunt factor by interpolating the table provided in
+section 5.1 of Kurucz (1970). The table was derived from a figure in Karsas and Latter (1961).
+
+# Arguments
+- `log_u::F`: Equal to log₁₀(u) = log₁₀(h*ν/(k*T))
+- `log_γ2::F`: Equal to log₁₀(γ²) = log₁₀(RydbergH*Z²/(k*T))
+
+# Note
+There is some ambiguity over whether we should replace RydbergH*Z² in the definition of γ² with the
+ionization energy, but it's probably a negligible difference (given the log scale).
+
+In the future, we may want to the interpolate the table reported in van Hoof, Ferland, Williams,
+Volk, Chatzikos, Lykins, & Porter (2013) because it's more accurate and applies over a larger range
+of values.
+"""
+gaunt_ff_kurucz(log_u, log_γ2) = _ff_interpolator(log_u, log_γ2)
+
+
+"""
     hydrogenic_ff_opacity(Z, ni, ne, ν, ρ, T)
 
 computes the free-free opacity for a hydrogenic species
 
+The naming convention for free-free absorption is counter-intuitive. A free-free interaction is
+named as though the species interacting with the free electron had one more bound electron (in 
+other words it's named as though the free-electron and ion were bound together). In practice, this
+means that `ni` should refer to:
+- the number density of H II if computing the H I free-free opacity
+- the number density of He III if computing the He II free-free opacity
+- the number density of Li IV if computing the Li III free-free opacity
+
 # Arguments
 - `Z::Integer`: the charge of the ion. For example, this is 1 for ionized H.
-- `ni::Flt`: the number density of the ion species.
+- `ni::Flt`: the number density of the ion species in cm⁻³.
 - `ne::Flt`: the number density of free electrons.
 - `ν::Flt`: frequency in Hz
 - `ρ::Flt`: mass density in g/cm³
@@ -238,16 +267,6 @@ be computed from eqn 5.18a).
 With this in mind, equation 5.8 of Kurucz (1970) should actually read
     ne * n(H II) * F_ν(T) * (1 - exp(-hplanck*ν/(kboltz*T))) / ρ
 where F_ν(T) = coef * Z² * g_ff / (sqrt(T) * ν³).
-
-To get g_ff, we interpolate values from the table given in section 5.1 of Kurucz (1970), which
-itself was derived from a figure in Karsas and Latter (1961). The table's x-axis is
-log₁₀(RydbergH*Z²/(k*T)) and the y-axis is log₁₀(h*ν/(k*T)). There is some ambiguity over whether we
-should replace RydbergH*Z² with the ionization energy, but it's probably a negligible difference
-(given the log scale).
-
-In the future, it may be worth considering interpolating the gaunt factors reported by
-van Hoof, Ferland, Williams, Volk, Chatzikos, Lykins, & Porter (2013, 2015). This data has been
-computed more recently presumably has more precision/accuracy.
 """
 function hydrogenic_ff_opacity(Z::Integer, ni::Flt, ne::Flt, ν::Flt, ρ::Flt,
                                T::Flt) where {Flt<:AbstractFloat}
@@ -255,12 +274,11 @@ function hydrogenic_ff_opacity(Z::Integer, ni::Flt, ne::Flt, ν::Flt, ρ::Flt,
     Z2 = convert(Flt, Z*Z)
 
     hν_div_kT = hplanck_eV * ν * β
-    ion_energy_div_kT = RydbergH_eV * Z2 * β
+    log_u = log10(hν_div_kT)
+    log_γ2 = log10(RydbergH_eV * Z2 * β)
+    gaunt_ff = gaunt_ff_kurucz(log_u, log_γ2)
 
-    # recall we pass in (y,x) to the interpolator
-    interpolated_value = _ff_interpolator(log10(hν_div_kT), log10(ion_energy_div_kT))
-
-    F_ν = 3.6919e8*interpolated_value*Z2/((ν*ν*ν)*sqrt(T))
+    F_ν = 3.6919e8*gaunt_ff*Z2/((ν*ν*ν)*sqrt(T))
 
     ni*ne*F_ν*(1-exp(-hν_div_kT))/ρ
 end

--- a/src/continuum_opacity/opacity_H.jl
+++ b/src/continuum_opacity/opacity_H.jl
@@ -8,7 +8,8 @@ const _H⁻_ion_energy = 0.7552 # eV
 
 H_I_bf(nH_I_div_partition, ν, ρ, T, ion_energy = _H_I_ion_energy) =
     hydrogenic_bf_opacity(1, 8, nH_I_div_partition, ν, ρ, T, ion_energy)
-H_I_ff(nH_I, ne, ν, ρ, T) = hydrogenic_ff_opacity(1, nH_I, ne, ν, ρ, T)
+# H I free-free actually refers to the reaction: photon + e⁻ + H II -> e⁻ + H II.
+H_I_ff(nH_II, ne, ν, ρ, T) = hydrogenic_ff_opacity(1, nH_II, ne, ν, ρ, T)
 
 # compute the number density of H⁻ (implements eqn 5.10 of Kurucz 1970). This formula comes from
 # inverting the saha equation, where n(H⁻) is n₀ and n(H I) is n₁. Note that U₀ = 1 at all

--- a/src/continuum_opacity/opacity_H.jl
+++ b/src/continuum_opacity/opacity_H.jl
@@ -6,8 +6,10 @@ const _H_I_ion_energy = ionization_energies["H"][1] # not sure if this is a good
 const _H⁻_ion_energy = 0.7552 # eV
 
 
-H_I_bf(nH_I_div_partition, ν, ρ, T, ion_energy = _H_I_ion_energy) =
-    hydrogenic_bf_opacity(1, 8, nH_I_div_partition, ν, ρ, T, ion_energy)
+H_I_bf(nH_I_div_partition, ν, ρ, T, ion_energy = _H_I_ion_energy,
+       nmax_explicit_sum = 8, integrate_high_n = true) =
+           hydrogenic_bf_opacity(1, nH_I_div_partition, ν, ρ, T, ion_energy, nmax_explicit_sum,
+                                 integrate_high_n)
 # H I free-free actually refers to the reaction: photon + e⁻ + H II -> e⁻ + H II.
 H_I_ff(nH_II, ne, ν, ρ, T) = hydrogenic_ff_opacity(1, nH_II, ne, ν, ρ, T)
 

--- a/src/continuum_opacity/opacity_H.jl
+++ b/src/continuum_opacity/opacity_H.jl
@@ -183,10 +183,10 @@ function Hminus_ff(nH_I_div_partition::Flt, ne::Flt, ν::Flt, ρ::Flt,
     # Pₑ * α_ff(H⁻) gives the absorption coefficient in units of cm² per ground state H I atom
     Pₑ = ne * kboltz_cgs * T
 
-    # in this case, I'm going to account for the fact that n(H I, n=1) might be slightly
-    # smaller than the entire number density of H I. This is only a difference at the highest
-    # temperatures. For the temperature range where this approximation is valid, less that
-    # 0.23% of all H I atoms are not in the ground state.
+    # Going to account for the fact that n(H I, n=1) might be slightly smaller than the entire
+    # number density of H I. This is only a difference at the highest temperatures. For the
+    # temperature range where this approximation is valid, less than 0.23% of all H I atoms are not
+    # in the ground state.
 
     # this calculation could reduce to nHI_gs = 2.0*nH_I_div_partition
     nHI_gs = ndens_state_hydrogenic(1, nH_I_div_partition, T, _H_I_ion_energy)

--- a/src/continuum_opacity/opacity_H.jl
+++ b/src/continuum_opacity/opacity_H.jl
@@ -186,8 +186,8 @@ function Hminus_ff(nH_I_div_partition::Flt, ne::Flt, ν::Flt, ρ::Flt,
     # Pₑ * α_ff(H⁻) gives the absorption coefficient in units of cm² per ground state H I atom
     Pₑ = ne * kboltz_cgs * T
 
-    # Going to account for the fact that n(H I, n=1) might be slightly smaller than the entire
-    # number density of H I. This is only a difference at the highest temperatures. For the
+    # Account for the fact that n(H I, n=1) might be slightly smaller than the entire number
+    # density of H I. There is only really a difference at the highest temperatures. For the
     # temperature range where this approximation is valid, less than 0.23% of all H I atoms are not
     # in the ground state.
 

--- a/src/continuum_opacity/opacity_He.jl
+++ b/src/continuum_opacity/opacity_He.jl
@@ -11,7 +11,8 @@ const _He_II_ion_energy = ionization_energies["He"][2] # not sure if this is a g
 
 He_II_bf(nHe_II_div_partition, ν, ρ, T, ion_energy = _He_ion_energy) =
     hydrogenic_bf_opacity(2, 9, nHe_II_div_partition, ν, ρ, T, ion_energy)
-He_II_ff(nHe_II, ne, ν, ρ, T) = hydrogenic_ff_opacity(2, nHe_II, ne, ν, ρ, T)
+# He II free-free actually refers to the reaction: photon + e⁻ + He III -> e⁻ + He III.
+He_II_ff(nHe_III, ne, ν, ρ, T) = hydrogenic_ff_opacity(2, nHe_III, ne, ν, ρ, T)
 
 
 # Compute the number density of atoms in different He I states

--- a/src/continuum_opacity/opacity_He.jl
+++ b/src/continuum_opacity/opacity_He.jl
@@ -9,8 +9,10 @@ We are currently missing free-free and bound free contributions from He I.
 using ..ContinuumOpacity: hydrogenic_bf_opacity, hydrogenic_ff_opacity, ionization_energies
 const _He_II_ion_energy = ionization_energies["He"][2] # not sure if this is a good idea
 
-He_II_bf(nHe_II_div_partition, ν, ρ, T, ion_energy = _He_ion_energy) =
-    hydrogenic_bf_opacity(2, 9, nHe_II_div_partition, ν, ρ, T, ion_energy)
+He_II_bf(nHe_II_div_partition, ν, ρ, T, ion_energy = _He_II_ion_energy,
+         nmax_explicit_sum = 9, integrate_high_n = true) =
+             hydrogenic_bf_opacity(1, nH_I_div_partition, ν, ρ, T, ion_energy, nmax_explicit_sum,
+                                   integrate_high_n)
 # He II free-free actually refers to the reaction: photon + e⁻ + He III -> e⁻ + He III.
 He_II_ff(nHe_III, ne, ν, ρ, T) = hydrogenic_ff_opacity(2, nHe_III, ne, ν, ρ, T)
 

--- a/test/continuum_opacity.jl
+++ b/test/continuum_opacity.jl
@@ -355,3 +355,18 @@ end
         end
     end
 end
+
+
+# this is only included here for completeness.
+# Given the strong consistency when comparing the bf and ff values individually against the
+# alternative implementations described in Gray (2005), I'm unconcerned by the need for large
+# tolerances.
+@testset "combine H I bf and ff opacity opacity" begin
+    @testset "Gray (2005) Fig 8.5$panel comparison" for (panel, atol) in [("b",0.035),
+                                                                          ("c",0.125),
+                                                                          ("d",35)]
+        calculated, ref = Gray05_comparison_vals(panel,"H")
+        @test all(calculated .≥ 0.0)
+        @test all(abs.(calculated - ref) .≤ atol)
+    end
+end

--- a/test/opacity_comparison_funcs.jl
+++ b/test/opacity_comparison_funcs.jl
@@ -96,10 +96,7 @@ function free_electrons_per_Hydrogen_particle(nₑ, T, abundances = solar_abunda
             continue
         end
 
-        #println(element, " ionization potentials = ", ion_energies, " ", length(Us),
-        #        " running sum = ", out)
         ion_state_weights = SSSynth.saha(χs, Us, T, nₑ)
-        #println(nₑ, " ", T, " weights = ", ion_state_weights)
         nₑ_per_ndens_species = 0.0
         for (i,ion_state_weight) in enumerate(ion_state_weights)
             num_electrons_from_state = i - 1
@@ -107,8 +104,6 @@ function free_electrons_per_Hydrogen_particle(nₑ, T, abundances = solar_abunda
         end
 
         abundance = 10.0^(abundances[element]-12.0)
-        #println("nₑ/n_", element, " =", nₑ_per_ndens_species,
-        #        " n_", element, "/n_H = ", abundance)
         out += abundance * nₑ_per_ndens_species
     end
     out
@@ -133,48 +128,35 @@ end
 
 # Now actually define the functions that compute the opacities in the form comparable with Gray05
 
-# This includes both bound-free and free-free, but I think bound-free dominates for our examples
+# Combined H I bound-free and free-free opacity
 function HI_coefficient(λ, T, Pₑ, H_I_ion_energy = 13.598)
     # λ should have units of Ångstroms
     # Pₑ is the partial pressure of the electrons in dyne/cm²
-    ne =  Pₑ/(SSSynth.kboltz_cgs * T)
-
-    # pick arbitrary values of nH and ρ. The values shouldn't really matter since we will just
-    # divide out all dependence on these variables.
-    nH = if true
-        100.0*ne
-    else # this is provided for testing purposes. I don't think this matters
-        ne_div_nH = free_electrons_per_Hydrogen_particle(ne, T, solar_abundance_dict,
-                                                         SSSynth.ionization_energies,
-                                                         SSSynth.partition_funcs)
-        ne/ne_div_nH
-    end
-    ρ = nH * 1.67e-24/0.76
-
-    # the free-free opacity calculation requires that the Saha equation is used to compute the
-    # ratio of nH_I to nH_II
-    χs = SSSynth.ionization_energies["H"][1:2]
-    # need to use the gray05 partition function to handle the 11572 K example
-    Us = [gray05_partition_funcs["H_I"], gray05_partition_funcs["H_II"]]
-    weights = SSSynth.saha(χs, Us, T, ne)
-    nH_I = weights[1]*nH
-    nH_II = weights[2]*nH
-
-    partition_func = 2.0 # may want to add temperature dependence to partition function
+    nₑ =  Pₑ/(SSSynth.kboltz_cgs * T)
     ν = (SSSynth.c_cgs*1e8)/λ
 
-    bf_opac = if true
-        SSSynth.ContinuumOpacity.H_I_bf(nH_I/partition_func, ν, ρ, T, H_I_ion_energy)
-    else
-        SSSynth.ContinuumOpacity.hydrogenic_bf_opacity(1, 10000, nH_I/partition_func,
-                                                       ν, ρ, T, H_I_ion_energy, false)
+    bf_coef = begin
+        H_I_partition_val = 2.0 # implicitly in the implementation provided by Gray (2005)
+        nH_I = nₑ * 100.0 # this is totally arbitrary
+        ρ = nH_I * 1.67e-24/0.76 # this is totally arbitrary
+        bf_opac = SSSynth.ContinuumOpacity.H_I_bf(nH_I/H_I_partition_val, ν, ρ, T, H_I_ion_energy)
+        bf_opac * ρ / (Pₑ * nH_I)
     end
 
-    ff_opac = SSSynth.ContinuumOpacity.H_I_ff(nH_II, ne, ν, ρ, T)
+    ff_coef = begin
+        χs = [H_I_ion_energy, -1.0]
+        Us = [T -> 2.0, T -> 1.0] # assumption in the approach described by Gray (2005)
+        nH_total = nₑ * 100.0 # this is totally arbitrary
+        ρ = nH_total * 1.67e-24/0.76 # this is totally arbitrary
 
-    #println(" λ = ", λ, " weights = ", weights, " bf_opac = ", bf_opac, " ff_opac = ", ff_opac)
+        weights = SSSynth.saha(χs, Us, T, nₑ)
+        nH_I = nH_total * weights[1]
+        nH_II = nH_total * weights[2]
+        ff_opac = SSSynth.ContinuumOpacity.H_I_ff(nH_II, nₑ, ν, ρ, T)
+        ff_opac * ρ / (Pₑ * nH_I)
+    end
 
-    (bf_opac + ff_opac) * ρ / (Pₑ * nH_I)
+    bf_coef + ff_coef
 end
 
 function Hminus_bf_coefficient(λ, T, Pₑ, ion_energy_H⁻ = 0.7552)
@@ -211,7 +193,7 @@ end
 
 # computes the combine H₂⁺ free-free and bound-free absorption in units of cm^2 per H atom (not a
 # typo)
-# There seems to be an in our function to compute H₂⁺
+# There seems to be an error in our function to compute H₂⁺
 function H2plus_coefficient(λ, T, Pₑ)
     # λ should have units of Ångstroms
     # Pₑ is the partial pressure of the electrons in dyne/cm²
@@ -307,7 +289,7 @@ const Gray05_opacity_form_funcs =
          "Hminus_bf"  => (Hminus_bf_coefficient,  Bounds(2250.0, 15000.0),  "H⁻ bound-free"),
          "Hminus_ff"  => (Hminus_ff_coefficient,  Bounds(2604.0, 113918.0), "H⁻ free-free"),
          "Heminus_ff" => (Heminus_ff_coefficient, Bounds(5e3, 1.5e5),       "He⁻ free-free"),
-         #"H2plus"     => (H2plus_coefficiient,    Bounds(nothing,nothing),   "H₂⁺ ff and bf"),
+         #"H2plus"     => (H2plus_coefficient,     Bounds(nothing,nothing),   "H₂⁺ ff and bf"),
          )
 
 # the absolute tolerances for values the opacity contributions from
@@ -315,7 +297,7 @@ const Gray05_opacity_form_funcs =
 #    - H⁻ free-free
 #    - He⁻ free-free
 # There is a much larger discrepancy between the summed H I bf and ff opacity at large λ. But
-# unlike for H₂⁺, this could simply be a consequence of the different approximations that are used
+# unlike for H₂⁺, this could simply be a consequence of the different approximaitons that are used
 const Gray05_atols = Dict("a" => 0.05, "b" => 0.02, "c" => 0.04)
 
 # this function is defined to make tests easier


### PR DESCRIPTION
The main purpose of this PR is to introduce tests confirming that the H I bf & H I ff opacities are computed correctly. These tests helped lead me to the bug introduced in PR #11.

For both the free-free and bound-free opacities, I wrote independent implementations based on the approaches described in Gray (2005). Because Gray (2005) both makes slightly different approximations and casts the constants into a completely separate form, I feel that these tests are a relatively robust accuracy check. I added an additional minor testset for the bound-free opacities, checking the validity of our integral approximation. 

I additionally created a test comparing the combined H I bf and H I ff opacity values to the tabulated curves from the panels of figure 8.5 from Gray (2005). The updated plots are provided below. As you can see, PR #11 largely reconciled the differences in the curves that I had previously shared. While some discrepancy still remains, I'm not concerned about it all; the individual tests (described in the last paragraph) indicate that there is reasonable agreement. The remaining discrepancy is plausibly described by differences in the approximations, which are:
- Gray (2005) suggests that the summation in the bound-free opacity can be replaced by an integral at smaller n values than Kurucz (1970); note that above ~4.45 microns Kurucz (1970)'s approach uses in a comparable or potentially more aggressive manner. This helps explain why our approach always gives smaller values.
- Gray (2005) suggests the use of a much older/analytic approximations for both sets of gaunt factors. I think this generally means that their results are less accurate.

If you want a more detailed description about the changes that were made, I would encourage you to take a look at the commit messages (they're fairly detailed).

**Future Work on Continuum Opacities:**
I've still got to fix the H₂⁺ ff and bf opacities, but I'll do that in a separate branch. After I do that, I'll start refactoring the continuum opacities so that we achieve better performance. At this point I think that the dominant continuum opacities are robust enough that we should be able to start generating realistic spectra.

**Plotted Opacities:**
Panel B (T = 6428 K, Pₑ = 10^1.77 dyne cm⁻²):
![test_b](https://user-images.githubusercontent.com/28722054/112766717-f45b4300-8fe0-11eb-9ef2-ec3ad8eea419.png)

Panel C (T = 7715 K, Pₑ = 10^2.50 dyne cm⁻²):
![test_c](https://user-images.githubusercontent.com/28722054/112766783-57e57080-8fe1-11eb-95c9-94912f63f79e.png)

Panel D (T = 11572 K, Pₑ = 10^2.76 dyne cm⁻²):
![test_d](https://user-images.githubusercontent.com/28722054/112766843-a3981a00-8fe1-11eb-9ba6-c93e80c07557.png)