### PR TITLE
new function to apply LSF

### DIFF
--- a/src/LSF.jl
+++ b/src/LSF.jl
@@ -1,11 +1,12 @@
 normal_pdf(Δ, σ) = exp(-0.5*Δ^2 / σ^2) / √(2π) / σ
 
 """
-Returns the matrix which transforms a spectrum to its LSF-convolved version for spectral resolution 
+Returns the matrix which a gaussian line spread function with constant spectral resolution, 
 (λ / Δλ) R.
 
 This will have weird behavior if your wavelength grid is not locally linearly-spaced.
-It is intended to be run on a fine wavelength grid, then downsampled to the observational (or otherwise desired) grid.
+It is intended to be run on a fine wavelength grid, then downsampled to the observational (or 
+otherwise desired) grid.
 """
 function constant_R_LSF(flux::AbstractVector{F}, wls, R) where F <: AbstractFloat
     #ideas - require wls to be a range object? Use erf to account for grid edges?

--- a/src/LSF.jl
+++ b/src/LSF.jl
@@ -1,0 +1,18 @@
+normal_pdf(Δ, σ) = exp(-0.5*Δ^2 / σ^2) / √(2π) / σ
+
+"""
+Returns the matrix which transforms a spectrum to its LSF-convolved version for spectral resolution 
+(λ / Δλ) R.
+
+This will have weird behavior if your wavelength grid is not locally linearly-spaced.
+It is intended to be run on a fine wavelength grid, then downsampled to the observational (or otherwise desired) grid.
+"""
+function line_spread_matrix(wls, R)
+    M = Matrix{Float64}(undef, length(wls), length(wls))
+    for i in 1:length(wls)
+        λ0 = wls[i]
+        M[i, :] = normal_pdf.(wls .- λ0, λ0 / R / 2)
+        M[i, :] /= sum(M[i, :])
+    end
+    M
+end

--- a/src/LSF.jl
+++ b/src/LSF.jl
@@ -1,8 +1,7 @@
 normal_pdf(Δ, σ) = exp(-0.5*Δ^2 / σ^2) / √(2π) / σ
 
 """
-Returns the matrix which a gaussian line spread function with constant spectral resolution, 
-(λ / Δλ) R.
+Applies a gaussian line spread function with constant spectral resolution, R = λ/Δλ.
 
 This will have weird behavior if your wavelength grid is not locally linearly-spaced.
 It is intended to be run on a fine wavelength grid, then downsampled to the observational (or 

--- a/src/SSSynth.jl
+++ b/src/SSSynth.jl
@@ -18,5 +18,6 @@ module SSSynth
 
     include("continuum_opacity/continuum_opacity.jl") #Define continuum opacity functions.
     include("synthesize.jl")                          #solve radiative transfer equation
+    include("LSF.jl")
 
 end # module

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -182,12 +182,13 @@ end
 @testset "LSF" begin
     wls = 5000:0.35:6000
     R = 1800.0
-    M = SSSynth.line_spread_matrix(wls, R)
-    
-    #normalized?
-    @test all(isapprox.(sum.(eachrow(M)), 1.0, atol=1e-5))
+    flux = zeros(Float64, length(wls))
+    flux[500] = 5.0
 
-    #centered on λ0?
-    @test argmax.(eachrow(M)) == 1:size(M, 1)
-    
+    convF = SSSynth.constant_R_LSF(flux, wls, R)
+    #normalized?
+    @test sum(flux) ≈ sum(convF)
+
+    #preserves line center?
+    @test argmax(convF) == 500
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -177,5 +177,17 @@ end
         xs = -10:0.1:10
         @test SSSynth.trapezoid_rule(xs, pdf.(xs) * 0.1) - 1.0 < 1e-5
     end
+end
+
+@testset "LSF" begin
+    wls = 5000:0.35:6000
+    R = 1800.0
+    M = SSSynth.line_spread_matrix(wls, R)
+    
+    #normalized?
+    @test all(isapprox.(sum.(eachrow(M)), 1.0, atol=1e-5))
+
+    #centered on λ0?
+    @test argmax.(eachrow(M)) == 1:size(M, 1)
     
 end


### PR DESCRIPTION
This introduces a function that calculates the matrix which maps spectra to LSF-convolved spectra, assuming the LSF is a gaussian with width set by a constant R = lambda/Delta lambda.  It assumes that the wavelength grid is locally-linear and dense, or it will not generally be normalized correctly.  In the future, I plan to automate the process of synthesizing on a dense grid, convolving with the LSF, and downsampling automatic, since it involves a few steps.

Here's the Ca triplet (what the Gaia RVS uses), with a realistic-ish LSF imposed.
![image](https://user-images.githubusercontent.com/711963/113179609-cf9fdf00-921d-11eb-85bc-66e09ef7c779.png)
