### PR TITLE
Fixed/updated H2plus opacity and updated Heminus ff opacity 

### DIFF
--- a/src/constants.jl
+++ b/src/constants.jl
@@ -8,6 +8,9 @@ const electron_mass_cgs = 9.1093897e-28 #g
 const electron_charge_cgs = 4.80320425e-10 # statcoulomb or cm^3/2 * g^1/2 / s
 const amu_cgs = 1.6605402e-24 #g
 
+# 2018 CODATA recommended value:
+const bohr_radius_cgs =  5.29177210903e-9 # cm
+
 const kboltz_eV = 8.617333262145e-5 #eV/K
 const hplanck_eV = 4.135667696e-15 #eV*s
 const RydbergH_eV = 13.595 #eV - this could be updated

--- a/src/continuum_opacity/opacity_H.jl
+++ b/src/continuum_opacity/opacity_H.jl
@@ -203,7 +203,7 @@ end
 
 Compute the combined H₂⁺ bound-free and free-free opacity κ.
 
-This uses polynomial fits from Gray (2005). that were derived from data tabulated in
+This uses polynomial fits from Gray (2005) that were derived from data tabulated in
 [Bates (1952)](https://ui.adsabs.harvard.edu/abs/1952MNRAS.112...40B/abstract).
 
 # Arguments
@@ -268,15 +268,12 @@ function H2plus_bf_and_ff(nH_I_div_partition::Float64, nH_II::Float64, ν::Float
     log2λ = logλ*logλ
     log3λ = log2λ*logλ
 
-    atomic_cross_section = begin
-        σ1 = -1040.54 + 1345.71 * logλ - 547.628 * log2λ + 71.9684 * log3λ
-        # there was a typo in Gray (2005). In the book they give the following polynomial
-        # as the fit for U₁. In reality, it is the fit for negative U₁
-        neg_U1 = 54.0532 - 32.713 * logλ + 6.6699 * log2λ - 0.4574 * log3λ
-
-        # note: Gray (2005) used the equivalent expression: σ1*10^(neg_U1 * θ) where θ = 5040/T
-        σ1 * exp(neg_U1 * β_eV)
-    end
+    σ1 = -1040.54 + 1345.71 * logλ - 547.628 * log2λ + 71.9684 * log3λ
+    # there was a typo in Gray (2005). In the book they give the following polynomial as the fit
+    # for U₁. In reality, it is the fit for negative U₁
+    neg_U1 = 54.0532 - 32.713 * logλ + 6.6699 * log2λ - 0.4574 * log3λ
+    # note: Gray (2005) used the equivalent expression: σ1*10^(neg_U1 * θ) where θ = 5040/T
+    atomic_cross_section = σ1 * exp(neg_U1 * β_eV)
 
     # see the docstring for an explanation of why we explicitly consider the ground state density
     nH_I_gs = ndens_state_hydrogenic(1, nH_I_div_partition, T, _H_I_ion_energy)

--- a/src/synthesize.jl
+++ b/src/synthesize.jl
@@ -161,8 +161,7 @@ function total_continuum_opacity(νs::Vector{F}, T::F, nₑ::F, ρ::F, number_de
     κ += ContinuumOpacity.H_I_ff.(number_densities["H_II"], nₑ, νs, ρ, T)
     κ += ContinuumOpacity.Hminus_bf.(nH_I_div_U, nₑ, νs, ρ, T)
     κ += ContinuumOpacity.Hminus_ff.(nH_I_div_U, nₑ, νs, ρ, T)
-    #TODO fix
-    #κ += ContinuumOpacity.H2plus_bf_and_ff.(nH_I_div_U, number_densities["H_II"], νs, ρ, T)
+    κ += ContinuumOpacity.H2plus_bf_and_ff.(nH_I_div_U, number_densities["H_II"], νs, ρ, T)
     
     #He continuum opacities
     κ += ContinuumOpacity.He_II_bf.(number_densities["He_II"]/partition_funcs["He_II"](T), νs, ρ, T)

--- a/src/synthesize.jl
+++ b/src/synthesize.jl
@@ -166,8 +166,9 @@ function total_continuum_opacity(νs::Vector{F}, T::F, nₑ::F, ρ::F, number_de
     #He continuum opacities
     κ += ContinuumOpacity.He_II_bf.(number_densities["He_II"]/partition_funcs["He_II"](T), νs, ρ, T)
     #κ += ContinuumOpacity.He_II_ff.(number_densities["He_III"], nₑ, νs, ρ, T)
-    κ += ContinuumOpacity.Heminus_ff.(number_densities["He_I"]/partition_funcs["He_I"](T), 
-                                      nₑ, νs, ρ, T)
+    # ContinuumOpacity.Heminus_ff is only valid for λ ≥ 5063 Å
+    #κ += ContinuumOpacity.Heminus_ff.(number_densities["He_I"]/partition_funcs["He_I"](T),
+    #                                  nₑ, νs, ρ, T)
     
     #electron scattering
     κ .+= ContinuumOpacity.electron_scattering(nₑ, ρ)

--- a/test/continuum_opacity.jl
+++ b/test/continuum_opacity.jl
@@ -213,8 +213,13 @@ function check_H2plus_ff_and_bf_opacity(target_precision, verbose = true)
     return success
 end
 
-@testset "H₂⁺ ff and bf opacity" begin
-    @test check_H2plus_ff_and_bf_opacity(0.111)
+@testset "combined H₂⁺ ff and bf opacity" begin
+    @test check_H2plus_ff_and_bf_opacity(0.015)
+    @testset "Gray (2005) Fig 8.5$panel comparison" for panel in ["b"]
+        calculated, ref = Gray05_comparison_vals(panel,"H2plus")
+        @test all(calculated .≥ 0.0)
+        @test all(abs.(calculated - ref) .≤ Gray05_atols[panel])
+    end
 end
 
 
@@ -428,7 +433,7 @@ end
 # Given the strong consistency when comparing the bf and ff values individually against the
 # alternative implementations described in Gray (2005), I'm unconcerned by the need for large
 # tolerances.
-@testset "combine H I bf and ff opacity opacity" begin
+@testset "combined H I bf and ff opacity" begin
     @testset "Gray (2005) Fig 8.5$panel comparison" for (panel, atol) in [("b",0.035),
                                                                           ("c",0.125),
                                                                           ("d",35)]

--- a/test/opacity_comparison_funcs.jl
+++ b/test/opacity_comparison_funcs.jl
@@ -280,7 +280,7 @@ const Gray05_opacity_form_funcs =
     Dict("H"          => (HI_coefficient,         Bounds(nothing, nothing), "H I bf and ff"),
          "Hminus_bf"  => (Hminus_bf_coefficient,  Bounds(2250.0, 15000.0),  "H⁻ bound-free"),
          "Hminus_ff"  => (Hminus_ff_coefficient,  Bounds(2604.0, 113918.0), "H⁻ free-free"),
-         "Heminus_ff" => (Heminus_ff_coefficient, Bounds(5e3, 1.5e5),       "He⁻ free-free"),
+         "Heminus_ff" => (Heminus_ff_coefficient, Bounds(5063.0, 151878.0), "He⁻ free-free"),
          "H2plus"     => (H2plus_coefficient,     Bounds(3847.0, 25000.0),   "H₂⁺ ff and bf"),
          )
 

--- a/test/opacity_comparison_funcs.jl
+++ b/test/opacity_comparison_funcs.jl
@@ -208,8 +208,6 @@ function H2plus_coefficient(λ, T, Pₑ)
     nH_I = weights[1]*nH
     nH_II = weights[2]*nH
 
-    println(nH_I, " ", nH_II)
-
     # set the partition function to 2.0 in nH_I_div_partition so that n(H I, n=1) = n(H I) for this
     # calculation, which is an assumption that Gray (2005) implicitly uses
     nH_I_div_partition = nH_I/2.0
@@ -217,7 +215,6 @@ function H2plus_coefficient(λ, T, Pₑ)
 
     ν = (SSSynth.c_cgs*1e8)/λ
     opacity = SSSynth.ContinuumOpacity.H2plus_bf_and_ff(nH_I_div_partition, nH_II, ν, ρ, T)
-    println(opacity)
     opacity * ρ / (Pₑ * nH_I)
 end
 
@@ -284,7 +281,7 @@ const Gray05_opacity_form_funcs =
          "Hminus_bf"  => (Hminus_bf_coefficient,  Bounds(2250.0, 15000.0),  "H⁻ bound-free"),
          "Hminus_ff"  => (Hminus_ff_coefficient,  Bounds(2604.0, 113918.0), "H⁻ free-free"),
          "Heminus_ff" => (Heminus_ff_coefficient, Bounds(5e3, 1.5e5),       "He⁻ free-free"),
-         #"H2plus"     => (H2plus_coefficient,     Bounds(nothing,nothing),   "H₂⁺ ff and bf"),
+         "H2plus"     => (H2plus_coefficient,     Bounds(3847.0, 25000.0),   "H₂⁺ ff and bf"),
          )
 
 # the absolute tolerances for values the opacity contributions from


### PR DESCRIPTION
I updated the implementation of `ContinuumOpacity.H2plus_bf_and_ff` so that it now works. I also updated `ContinuumOpacity.Heminus_ff` to enforce the valid wavelength range. 

Unfortunately the minimum wavelength at which we can evaluate `ContinuumOpacity.Heminus_ff` is 506.3 nm, which is right in the middle of the visible wavelength range. For now, I've commented the call to this function in `total_continuum_opacity` to avoid errors. I'm really not sure if there is an alternative implementation that we can use. I'm pretty sure that MARCS uses the same approach.

I also introduced some tests for `ContinuumOpacity.H2plus_bf_and_ff` and a new test for `ContinuumOpacity.Heminus_ff`. Here is the updated comparison against the only panel of figure 8.5 from Gray (2005) that includes non-neglible H₂⁺ ff and bf opacity.
![test_b](https://user-images.githubusercontent.com/28722054/113519592-380ef900-955b-11eb-8394-522fb985098f.png)


