### PR TITLE
Fixed typos in error message for get_absolute_abundances

### DIFF
--- a/src/synthesize.jl
+++ b/src/synthesize.jl
@@ -80,7 +80,7 @@ metallicity [X/H] to calculate those remaining from the solar values (except He)
 function get_absolute_abundances(elements, metallicity, A_X::Dict)::Dict
     if "H" in keys(A_X)
         throw(ArgumentError("A(H) set, but A(H) = 12 by definition. Adjust \"metallicity\" and "
-                           * "\"abundnances\" to implicitely set the ammount of H"))
+                           * "\"abundances\" to implicitly set the amount of H"))
     end
 
     #populate dictionary of absolute abundaces


### PR DESCRIPTION
Really trivial PR. It feels like a bit of a waste to make this a full PR