### PR TITLE
make optional arguments for synthesize into keyword arguments

### DIFF
--- a/src/synthesize.jl
+++ b/src/synthesize.jl
@@ -23,7 +23,7 @@ optional arguments:
 
 Uses solar abundances scaled by `metallicity` and for those not provided.
 """
-function synthesize(atm, linelist, λs::AbstractVector{F}, metallicity::F=0.0; vmic=1.0, 
+function synthesize(atm, linelist, λs::AbstractVector{F}; metallicity::F=0.0, vmic=1.0,
                     abundances=Dict(), line_window::F=10.0, 
                     ionization_energies=ionization_energies, 
                     partition_funcs=partition_funcs,


### PR DESCRIPTION
This small change makes the signature for synthesize what I intended all along.