### PR TITLE
move references from README to docs page

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,3 @@
 1D LTE stellar spectral synthesis in pure julia.
 
 [Read the docs!](https://ajwheeler.github.io/SSSynth.jl/dev/)
-
-# citations
- - Partition functions: [Barklem & Collet 2016](https://ui.adsabs.harvard.edu/abs/2016A%26A...588A..96B/abstract)
- - Voigt function approximation: [Hunger 1965](https://ui.adsabs.harvard.edu/abs/1956ZA.....39...36H/abstract) via _New Series in Astrophysics_,Landolt-Bornstein (same as MOOG)
- - ionization energies: Haynes, W.M. 2010, CRC Handbook of Chemistry and Physics, 91st edn. (CRC Press, Taylor and Francis Group) via [Barklem & Collet 2016](https://ui.adsabs.harvard.edu/abs/2016A%26A...588A..96B/abstract)
- - Hydrogenic bound-free and free-free opacities and H₂⁺ continuum opacities: [Kurucz 1970](https://ui.adsabs.harvard.edu/abs/1970SAOSR.309.....K/abstract)
- - H⁻ bound-free opacity: [Wishart 1979](https://ui.adsabs.harvard.edu/abs/1979MNRAS.187P..59W/abstract) via a polynomial-fit provided in [Gray 2005](https://ui.adsabs.harvard.edu/abs/2005oasp.book.....G/abstract)
- - H⁻ free-free opacity: [Bell & Berrington 1987](https://iopscience.iop.org/article/10.1088/0022-3700/20/4/019/pdf) via a polynomial-fit provided in [Gray 2005](https://ui.adsabs.harvard.edu/abs/2005oasp.book.....G/abstract)
- - He⁻ free-free opacity: [John 1994](https://ui.adsabs.harvard.edu/abs/1994MNRAS.269..871J/abstract) via a polynomial fit provided in [Gray 2005](https://ui.adsabs.harvard.edu/abs/2005oasp.book.....G/abstract)

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -5,8 +5,9 @@ using Documenter, SSSynth
 makedocs(sitename="SSSynth Documentation", 
          modules=[SSSynth],
          pages=[
-                "Quickstart" => "index.md",
+                "Quickstart" => "index.md"
                 "All Functions" => "API.md"
+                "References" => "refs.md"
                ])
 
 deploydocs(repo = "github.com/ajwheeler/SSSynth.jl.git",

--- a/docs/src/refs.md
+++ b/docs/src/refs.md
@@ -1,0 +1,9 @@
+The data and approximations used in SSSynth come from these papers:
+
+ - Partition functions: [Barklem & Collet 2016](https://ui.adsabs.harvard.edu/abs/2016A%26A...588A..96B/abstract)
+ - Voigt function approximation: [Hunger 1965](https://ui.adsabs.harvard.edu/abs/1956ZA.....39...36H/abstract) via _New Series in Astrophysics_,Landolt-Bornstein (same as MOOG)
+ - ionization energies: Haynes, W.M. 2010, CRC Handbook of Chemistry and Physics, 91st edn. (CRC Press, Taylor and Francis Group) via [Barklem & Collet 2016](https://ui.adsabs.harvard.edu/abs/2016A%26A...588A..96B/abstract)
+ - Hydrogenic bound-free and free-free opacities and H₂⁺ continuum opacities: [Kurucz 1970](https://ui.adsabs.harvard.edu/abs/1970SAOSR.309.....K/abstract)
+ - H⁻ bound-free opacity: [Wishart 1979](https://ui.adsabs.harvard.edu/abs/1979MNRAS.187P..59W/abstract) via a polynomial-fit provided in [Gray 2005](https://ui.adsabs.harvard.edu/abs/2005oasp.book.....G/abstract)
+ - H⁻ free-free opacity: [Bell & Berrington 1987](https://iopscience.iop.org/article/10.1088/0022-3700/20/4/019/pdf) via a polynomial-fit provided in [Gray 2005](https://ui.adsabs.harvard.edu/abs/2005oasp.book.....G/abstract)
+ - He⁻ free-free opacity: [John 1994](https://ui.adsabs.harvard.edu/abs/1994MNRAS.269..871J/abstract) via a polynomial fit provided in [Gray 2005](https://ui.adsabs.harvard.edu/abs/2005oasp.book.....G/abstract)


### PR DESCRIPTION
Moves the references in the README to a new page in the docs.

BTW, let me know if you are editing the docs aren't sure about anything (e.g. how to build locally).